### PR TITLE
[Line] Add the product management message utils.

### DIFF
--- a/src/shared/line/postback_action_models.py
+++ b/src/shared/line/postback_action_models.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class ProductRemovalPostbackDataModel(BaseModel):
+    action = "remove"
+    product_code: str

--- a/src/shared/line/product_management.py
+++ b/src/shared/line/product_management.py
@@ -1,0 +1,52 @@
+from linebot import models
+
+from src.shared.uq.uq_product import UqProduct
+from src.shared.line.postback_action_models import ProductRemovalPostbackDataModel
+
+
+class UqProductManagementTemplateMessageCreator:
+    """
+    Class for creating the carousel template message for user product management.
+    """
+
+    _uq_products: list[UqProduct]
+
+    def __init__(self, products: list[UqProduct]):
+        # Decided not to use DI here because we heavily rely on data models.
+        self._uq_products = products
+
+    def generate_products_carousel_template_message(self):
+        carousel_template_columns = [
+            self._generate_product_carousel_column(product)
+            for product in self._uq_products
+        ]
+        template = models.CarouselTemplate(columns=carousel_template_columns)
+        return models.TemplateSendMessage(template=template)
+
+    def _generate_product_carousel_column(self, product: UqProduct):
+        card_title = product.name
+        card_text = f"NT ${product.special_offer}"
+        go_website_button = self._generate_product_go_website_action(product)
+        removal_button = self._generate_product_removal_action(product)
+        return models.CarouselColumn(
+            title=card_title,
+            text=card_text,
+            actions=[go_website_button, removal_button],
+        )
+
+    def _generate_product_removal_action(self, product: UqProduct):
+        action_button_label = "取消追蹤"
+        action_button_click_message = f"取消追蹤 {product.name}"
+        postback_data = ProductRemovalPostbackDataModel(
+            product_code=product.product_code
+        ).json()
+        return models.PostbackAction(
+            display_text=action_button_click_message,
+            label=action_button_label,
+            data=postback_data,
+        )
+
+    def _generate_product_go_website_action(self, product: UqProduct):
+        action_button_label = "前往官網"
+        action_button_url = product.website_url
+        return models.URIAction(label=action_button_label, uri=action_button_url)

--- a/tests/ut/shared/line/test_product_management.py
+++ b/tests/ut/shared/line/test_product_management.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest import mock
+
+from linebot import models
+
+from src.shared.line.postback_action_models import ProductRemovalPostbackDataModel
+from src.shared.line.product_management import UqProductManagementTemplateMessageCreator
+
+
+class TestUqProductManagementTemplateMessageCreator(unittest.TestCase):
+    def test_generate_products_carousel_template_should_contain_products_info_in_column(
+        self,
+    ):
+        product1 = mock.MagicMock()
+        product1.name = "product1"
+        product1.product_code = "product_code1"
+        product1.website_url = "https://abcd.com/product1"
+        product1.special_offer = 100
+        product2 = mock.MagicMock()
+        product2.name = "product2"
+        product2.product_code = "product_code2"
+        product2.website_url = "https://abcd.com/product2"
+        product2.special_offer = 200
+
+        creator = UqProductManagementTemplateMessageCreator([product1, product2])
+        message = creator.generate_products_carousel_template_message()
+        column1 = message.template.columns[0]
+        column2 = message.template.columns[1]
+
+        self.assertEquals(2, len(message.template.columns))
+        self.assertEquals("product1", column1.title)
+        self.assertEquals("NT $100", column1.text)
+        self.assertEquals("product2", column2.title)
+        self.assertEquals("NT $200", column2.text)
+
+    def test_products_carousel_template_column_should_contain_go_website_and_removal_actions(
+        self,
+    ):
+        product1 = mock.MagicMock()
+        product1.name = "product1"
+        product1.product_code = "product_code1"
+        product1.website_url = "https://abcd.com/product1"
+        product1.special_offer = 100
+
+        creator = UqProductManagementTemplateMessageCreator([product1])
+        message = creator.generate_products_carousel_template_message()
+        column1 = message.template.columns[0]
+        go_website_button = column1.actions[0]
+        removal_button = column1.actions[1]
+
+        self.assertIsInstance(go_website_button, models.URIAction)
+        self.assertIsInstance(removal_button, models.PostbackAction)
+
+    def test_products_carousel_template_column_go_website_button_link_should_be_product_website(
+        self,
+    ):
+        product1 = mock.MagicMock()
+        product1.name = "product1"
+        product1.product_code = "product_code1"
+        product1.website_url = "https://abcd.com/product1"
+        product1.special_offer = 100
+
+        creator = UqProductManagementTemplateMessageCreator([product1])
+        message = creator.generate_products_carousel_template_message()
+        column1 = message.template.columns[0]
+        go_website_button = column1.actions[0]
+
+        self.assertEquals(product1.website_url, go_website_button.uri)
+
+    def test_products_carousel_template_column_removal_button_link_should_contain_correct_data(
+        self,
+    ):
+        product1 = mock.MagicMock()
+        product1.name = "product1"
+        product1.product_code = "product_code1"
+        product1.website_url = "https://abcd.com/product1"
+        product1.special_offer = 100
+
+        creator = UqProductManagementTemplateMessageCreator([product1])
+        message = creator.generate_products_carousel_template_message()
+        column1 = message.template.columns[0]
+        removal_button = column1.actions[1]
+        removal_postback_data = ProductRemovalPostbackDataModel.parse_raw(
+            removal_button.data
+        )
+
+        self.assertEquals("remove", removal_postback_data.action)
+        self.assertEquals("product_code1", removal_postback_data.product_code)


### PR DESCRIPTION
> Commit e4e2ea2 is not in the scope of this PR. It's here because the PR needs the implementation from #7. I will drop this commit and rebase the branch once #7 is closed.

# Quick demo

![image](https://user-images.githubusercontent.com/38838945/151302180-d3fd178e-1fc8-4ad0-9459-64d8ca3ba383.png)

# Description

The class `UqProductManagementCardsCreator` is responsible for creating the message template.
