### PR TITLE
Use CMD in the dev dockerfile.

### DIFF
--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -10,4 +10,4 @@ COPY Pipfile.lock /usr/src/app/Pipfile.lock
 
 RUN pipenv install --system --dev
 
-ENTRYPOINT ["bash"]
+CMD "bash"


### PR DESCRIPTION
The `entrypoint` command will append arguments from the `docker exec` command which is not desired for the current flow. For instance, `docker exec -it XXX pylint .`