### PR TITLE
Add product subscription callback handling logic

### DIFF
--- a/src/app/event_handlers.py
+++ b/src/app/event_handlers.py
@@ -13,6 +13,7 @@ from src.shared.line.message_creators.basic_message_creators import (
 from src import config
 from src.shared.uq.uq_url_utils import UqProductCodeParser
 from src.shared.uq import uq_product
+from src.app.postback_handlers import postback_dispatcher
 
 line_api = linebot.LineBotApi(config.LINE_CHANNEL_TOKEN, config.LINE_API_ENDPOINT)
 webhook_handler = linebot.WebhookHandler(config.LINE_CHANNEL_SECRET)
@@ -47,6 +48,9 @@ def generate_response_for_given_product_code(product_code: str) -> LineMessageCr
 
 
 @webhook_handler.add(PostbackEvent)
-def handle_postback_event(event: PostbackEvent):  # pylint: disable=W0613
-    # TODO: Postback event handling logic  pylint: disable=W0511
-    pass
+def handle_postback_event(event: PostbackEvent):
+    # Currently, only normal users can interact with our bot.
+    if event.source.type != "user":
+        return
+    response = postback_dispatcher.run_task(event.postback.data, event.source.user_id)
+    line_api.reply_message(event.reply_token, response)

--- a/src/app/postback_dispatcher.py
+++ b/src/app/postback_dispatcher.py
@@ -1,0 +1,63 @@
+import json
+from typing import Type
+
+from linebot.models import Message
+
+from src.app.postback_handler_base import PostbackHandlerBase
+from src.shared.line.postback_action_models import PostbackDataException
+
+
+class PostbackDispatcherError(Exception):
+    pass
+
+
+class PostbackDispatcher:
+    _handler_registry: dict[str, Type[PostbackHandlerBase]]
+
+    def __init__(self):
+        self._handler_registry = {}
+
+    def add(self, action: str):
+        """
+        Register a postback handler.
+        Args:
+            action: unique action code
+        """
+
+        def deco(cls: Type[PostbackHandlerBase]):
+            if action in self._handler_registry:
+                raise KeyError(
+                    f"Postback handler for action '{action}' has been registered."
+                )
+
+            self._handler_registry[action] = cls
+            return cls
+
+        return deco
+
+    def run_task(self, data: str, source_user_id: str) -> Message:
+        action = self._extract_action(data)
+        try:
+            handler = self._handler_registry[action](data, source_user_id)
+            response = handler.execute()
+            return response
+        except KeyError as e:
+            raise PostbackDispatcherError(
+                f"No Postback handler registered for the {action} action."
+            ) from e
+        except PostbackDataException as e:
+            raise PostbackDispatcherError(
+                "Postback data is not compatible with the registered handler."
+            ) from e
+
+    def _extract_action(self, data: str) -> str:
+        try:
+            return json.loads(data)["action"]
+        except json.JSONDecodeError as e:
+            raise PostbackDispatcherError(
+                "The postback data is not in json format."
+            ) from e
+        except (KeyError, IndexError) as e:
+            raise PostbackDispatcherError(
+                "Postback data is not in the right format: no action field."
+            ) from e

--- a/src/app/postback_handler_base.py
+++ b/src/app/postback_handler_base.py
@@ -1,0 +1,34 @@
+import abc
+
+from linebot.models import Message
+from pydantic import ValidationError
+
+from src.shared.line.postback_action_models import (
+    PostbackDataModelBase,
+    PostbackDataException,
+)
+
+
+class PostbackHandlerBase(abc.ABC):
+    _raw_data: str
+    _source_user_id: str
+
+    # OVERRIDE
+    _DATA_MODEL = PostbackDataModelBase
+
+    _data: _DATA_MODEL
+
+    def __init__(self, raw_data: str, source_user_id: str):
+        self._raw_data = raw_data
+        self._source_user_id = source_user_id
+        self._parse_data()
+
+    def _parse_data(self):
+        try:
+            self._data = self._DATA_MODEL.parse_raw(self._raw_data)
+        except ValidationError as e:
+            raise PostbackDataException from e
+
+    @abc.abstractmethod
+    def execute(self) -> Message:
+        pass

--- a/src/app/postback_handlers.py
+++ b/src/app/postback_handlers.py
@@ -1,0 +1,45 @@
+import requests
+
+from src.app.postback_dispatcher import PostbackDispatcher
+from src.app.postback_handler_base import PostbackHandlerBase
+from src.shared.line.postback_action_models import ProductAddingConfirmationDataModel
+from src.shared.db.models import User, Product, UserProduct
+from src.shared.db.utils import UserDataRetriever
+from src.shared.line.message_creators.basic_message_creators import (
+    ProductAlreadyInListMessageCreator,
+    ProductSuccessfullyAddedMessageCreator,
+)
+from src.shared.uq.uq_product import UqProduct, UqRetriever
+
+postback_dispatcher = PostbackDispatcher()
+
+
+@postback_dispatcher.add("add")
+class ProductSubscriptionPostbackHandler(PostbackHandlerBase):
+    _DATA_MODEL = ProductAddingConfirmationDataModel
+
+    def execute(self):
+        (user, _) = User.get_or_create(id=self._source_user_id, role_id=1)
+
+        products = UserDataRetriever(user).get_subscribed_products()
+        if self._data.product_code in products:
+            product_name = products[self._data.product_code].name
+            return ProductAlreadyInListMessageCreator(
+                product_name=product_name
+            ).generate()
+
+        with requests.Session() as session:
+            uq_product = UqProduct(UqRetriever(self._data.product_code, session))
+            (product, _) = Product.get_or_create(
+                product_code=uq_product.product_code,
+                name=uq_product.name,
+                current_price=uq_product.special_offer,
+                original_price=uq_product.original_price,
+                short_description=uq_product.name,
+            )
+
+        UserProduct.create(user=user, product=product)
+
+        return ProductSuccessfullyAddedMessageCreator(
+            product_name=product.name
+        ).generate()

--- a/src/shared/db/utils.py
+++ b/src/shared/db/utils.py
@@ -1,0 +1,17 @@
+from src.shared.db.models import User, Product, UserProduct
+
+
+class UserDataRetriever:
+    _user: User
+
+    def __init__(self, user: User):
+        self._user = user
+
+    def get_subscribed_products(self) -> dict[str, Product]:
+        products = (
+            Product.select()
+            .join(UserProduct)
+            .join(User)
+            .where(User.id == self._user.id)
+        )
+        return {product.product_code: product for product in products}

--- a/src/shared/line/message_creators/basic_message_creators.py
+++ b/src/shared/line/message_creators/basic_message_creators.py
@@ -16,3 +16,23 @@ class PriceDownNotificationMessageCreator(LineMessageCreator):
 class ProductUrlErrorMessageCreator(LineMessageCreator):
     def generate(self) -> models.TextMessage:
         return models.TextMessage(text="你所輸入的商品網址有誤，請重新輸入！")
+
+
+class ProductSuccessfullyAddedMessageCreator(LineMessageCreator):
+    product_name: str
+
+    def __init__(self, product_name: str):
+        self.product_name = product_name
+
+    def generate(self) -> models.TextMessage:
+        return models.TextMessage(text=f"已成功將{self.product_name}加入追蹤清單！")
+
+
+class ProductAlreadyInListMessageCreator(LineMessageCreator):
+    product_name: str
+
+    def __init__(self, product_name: str):
+        self.product_name = product_name
+
+    def generate(self) -> models.TextMessage:
+        return models.TextMessage(text=f"{self.product_name}已經在你的追蹤清單了喔！")

--- a/src/shared/line/postback_action_models.py
+++ b/src/shared/line/postback_action_models.py
@@ -1,11 +1,19 @@
 from pydantic import BaseModel
 
 
-class ProductRemovalPostbackDataModel(BaseModel):
+class PostbackDataException(Exception):
+    pass
+
+
+class PostbackDataModelBase(BaseModel):
+    action: str
+
+
+class ProductRemovalPostbackDataModel(PostbackDataModelBase):
     action = "remove"
     product_code: str
 
 
-class ProductAddingConfirmationDataModel(BaseModel):
+class ProductAddingConfirmationDataModel(PostbackDataModelBase):
     action = "add"
     product_code: str

--- a/tests/ut/app/test_postback_dispatcher.py
+++ b/tests/ut/app/test_postback_dispatcher.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest import mock
+
+from src.app.postback_dispatcher import PostbackDispatcher, PostbackDispatcherError
+from src.shared.line.postback_action_models import PostbackDataException
+
+
+class TestPostbackDispatcher(unittest.TestCase):
+    def test_using_add_decorator_to_register_handler(self):
+        dispatcher = PostbackDispatcher()
+
+        @dispatcher.add("add")
+        class Handler(mock.MagicMock):
+            pass
+
+        self.assertIn("add", dispatcher._handler_registry)
+        self.assertIs(Handler, dispatcher._handler_registry["add"])
+
+    def test_using_add_decorator_to_add_duplicated_handler_should_raise_key_error(self):
+        dispatcher = PostbackDispatcher()
+
+        @dispatcher.add("add")
+        class Handler1(mock.MagicMock):
+            pass
+
+        with self.assertRaisesRegex(
+            KeyError, "Postback handler for action 'add' has been registered."
+        ):
+
+            @dispatcher.add("add")
+            class Handler2(mock.MagicMock):
+                pass
+
+    def test_run_task_should_raise_exception_if_data_is_not_json_format(self):
+        dispatcher = PostbackDispatcher()
+        with self.assertRaisesRegex(
+            PostbackDispatcherError, "The postback data is not in json format."
+        ):
+            dispatcher.run_task("not json-parsable data", "user_id")
+
+    def test_run_task_should_raise_exception_if_data_has_no_action_field(self):
+        dispatcher = PostbackDispatcher()
+        with self.assertRaisesRegex(PostbackDispatcherError, "no action field."):
+            dispatcher.run_task("{}", "user_id")
+
+    def test_run_task_should_raise_exception_if_no_corresponding_handler_registered(
+        self,
+    ):
+        dispatcher = PostbackDispatcher()
+        with self.assertRaisesRegex(
+            PostbackDispatcherError,
+            "No Postback handler registered for the no_handler action.",
+        ):
+            dispatcher.run_task('{"action": "no_handler"}', "user_id")
+
+    def test_run_task_should_raise_exception_if_data_parsing_failed(self):
+        dispatcher = PostbackDispatcher()
+
+        @dispatcher.add("add")
+        class Handler(mock.MagicMock):
+            pass
+
+        Handler.__init__ = mock.MagicMock(side_effect=PostbackDataException)
+
+        with self.assertRaisesRegex(
+            PostbackDispatcherError,
+            "Postback data is not compatible with the registered handler.",
+        ):
+            dispatcher.run_task('{"action": "add"}', "user_id")
+
+    def test_run_task_should_return_result_of_execute_method_of_registered_handler(
+        self,
+    ):
+        dispatcher = PostbackDispatcher()
+        response = "response message object"
+
+        @dispatcher.add("add")
+        class Handler(mock.MagicMock):
+            def execute(self):
+                return response
+
+        actual_response = dispatcher.run_task('{"action": "add"}', "user_id")
+
+        self.assertIs(actual_response, response)

--- a/tests/ut/app/test_postback_handlers.py
+++ b/tests/ut/app/test_postback_handlers.py
@@ -1,0 +1,104 @@
+from typing import Type
+import unittest
+from unittest import mock
+
+from linebot import models
+
+from src.app.postback_handlers import ProductSubscriptionPostbackHandler
+from src.shared.line.postback_action_models import (
+    ProductAddingConfirmationDataModel,
+    PostbackDataException,
+)
+
+
+class TestProductSubscriptionPostbackHandler(unittest.TestCase):
+    def test_product_adding_confirmation_data_model_is_used_to_parse_data(self):
+        data = ProductAddingConfirmationDataModel(product_code="code")
+
+        handler = ProductSubscriptionPostbackHandler(data.json(), "user_id")
+
+        self.assertEqual(handler._data.action, "add")
+        self.assertEqual(handler._data.product_code, "code")
+
+    def test_init_should_raise_postback_data_exception_if_validation_failed(self):
+        with self.assertRaises(PostbackDataException):
+            ProductSubscriptionPostbackHandler("wrong data", "user_id")
+
+    @mock.patch("src.app.postback_handlers.UserDataRetriever")
+    @mock.patch("src.app.postback_handlers.User")
+    def test_execute_should_return_product_in_list_message_if_product_to_add_already_in_list(
+        self, mock_user: Type[mock.MagicMock], mock_retriever: Type[mock.MagicMock]
+    ):
+        """
+        We didn't mock ProductAlreadyInListMessageCreator since 1) testing return value is
+        easier to maintain than testing interaction and 2) the side effect of the class is
+        limited.
+        """
+        # set up mock User to return a dummy user object
+        dummy_user = mock.MagicMock()
+        mock_user.get_or_create.return_value = (dummy_user, False)
+        # set up mock get_subscribed_products of UserDataRetriever class
+        user_data_retriever_instance = mock.MagicMock()
+        product1 = mock.MagicMock()
+        product1.name = "product1"
+        user_data_retriever_instance.get_subscribed_products.return_value = {
+            "product1": product1,
+        }
+        mock_retriever.return_value = user_data_retriever_instance
+        # prepare postback data
+        data = ProductAddingConfirmationDataModel(product_code="product1")
+
+        response = ProductSubscriptionPostbackHandler(data.json(), "user_id").execute()
+
+        self.assertIsInstance(response, models.TextMessage)
+        self.assertEqual(response.text, "product1已經在你的追蹤清單了喔！")
+
+    @mock.patch("src.app.postback_handlers.UserProduct")
+    @mock.patch("src.app.postback_handlers.Product")
+    @mock.patch("src.app.postback_handlers.UqProduct")
+    @mock.patch("src.app.postback_handlers.UqRetriever")
+    @mock.patch("requests.Session")
+    @mock.patch("src.app.postback_handlers.UserDataRetriever")
+    @mock.patch("src.app.postback_handlers.User")
+    def test_execute_should_succeful_operation_if_correctly_adding_the_product_to_list(
+        self,
+        mock_user: Type[mock.MagicMock],
+        mock_user_data_retriever: Type[mock.MagicMock],
+        mock_session: Type[mock.MagicMock],
+        mock_uq_retriever: Type[mock.MagicMock],
+        mock_uq_product: Type[mock.MagicMock],
+        mock_product: Type[mock.MagicMock],
+        mock_user_product: Type[mock.MagicMock],
+    ):
+        """
+        We didn't mock ProductSuccessfullyAddedMessageCreator since 1) testing return value is
+        easier to maintain than testing interaction and 2) the side effect of the class is
+        limited.
+        """
+        dummy_user = mock.MagicMock()
+        mock_user.get_or_create.return_value = (dummy_user, False)
+        # set up mock get_subscribed_products of UserDataRetriever class
+        user_data_retriever_instance = mock.MagicMock()
+        user_data_retriever_instance.get_subscribed_products.return_value = {}
+        mock_user_data_retriever.return_value = user_data_retriever_instance
+        # set up UqProduct data
+        dummy_uq_product = mock.MagicMock()
+        dummy_uq_product.configure_mock(
+            product_code="product_code",
+            name="name",
+            current_price=100,
+            original_price=50,
+            short_description="short_description",
+        )
+        mock_uq_product.return_value = dummy_uq_product
+        # Set up get_or_create of Product class
+        dummy_product = mock.MagicMock()
+        dummy_product.name = "name"
+        mock_product.get_or_create.return_value = (dummy_product, False)
+        # prepare postback data
+        data = ProductAddingConfirmationDataModel(product_code="product_code")
+
+        response = ProductSubscriptionPostbackHandler(data.json(), "user_id").execute()
+
+        self.assertIsInstance(response, models.TextMessage)
+        self.assertEqual(response.text, "已成功將name加入追蹤清單！")

--- a/tests/ut/shared/line/message_creators/test_basic_message_creators.py
+++ b/tests/ut/shared/line/message_creators/test_basic_message_creators.py
@@ -3,6 +3,8 @@ import unittest
 from src.shared.line.message_creators.basic_message_creators import (
     HelpMessageCreator,
     PriceDownNotificationMessageCreator,
+    ProductSuccessfullyAddedMessageCreator,
+    ProductAlreadyInListMessageCreator
 )
 
 
@@ -20,3 +22,21 @@ class TestPriceDownNotificationMessageCreator(unittest.TestCase):
         message = creator.generate()
 
         self.assertEqual("你好，你追蹤的商品正在特價中！把握機會購買吧！", message.text)
+
+
+class TestProductSuccessfullyAddedMessageCreator(unittest.TestCase):
+    def test_product_successfully_added_message_should_contain_correct_message(self):
+        product_name = "product_name"
+        creator = ProductSuccessfullyAddedMessageCreator(product_name)
+        message = creator.generate()
+
+        self.assertEqual("已成功將product_name加入追蹤清單！", message.text)
+
+
+class TestProductAlreadyInListMessageCreator(unittest.TestCase):
+    def test_product_already_in_list_message_should_contain_correct_message(self):
+        product_name = "product_name"
+        creator = ProductAlreadyInListMessageCreator(product_name)
+        message = creator.generate()
+
+        self.assertEqual("product_name已經在你的追蹤清單了喔！", message.text)


### PR DESCRIPTION
# Description
To subscribe to a product, users need to proceed with the following steps.
1. Send the product URL to the channel.
2. Click the confirmation button on the confirmation template message.

After clicking the button at step 2, LINE will send a callback message to our service with predefined data. This PR aims to handle the product subscription callback flow.
